### PR TITLE
Optimize testsuite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,8 +803,6 @@ version = "0.0.0"
 dependencies = [
  "cradle",
  "hex-literal",
- "lnd-client",
- "openssl",
  "pretty_assertions",
  "reqwest",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,6 @@ features = ["blocking", "stream"]
 name = "smoke"
 path = "tests/smoke.rs"
 test = false
+
+[profile.dev]
+debug = false

--- a/lnd-client/src/lib.rs
+++ b/lnd-client/src/lib.rs
@@ -82,7 +82,6 @@ impl Client {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use lnd_test_context::LndTestContext;
 
   #[tokio::test]
   async fn ping() {

--- a/lnd-test-context/Cargo.toml
+++ b/lnd-test-context/Cargo.toml
@@ -11,8 +11,6 @@ doctest = false
 [dependencies]
 cradle = "0.0.4"
 hex-literal = "0.3.1"
-lnd-client = { path = "../lnd-client" }
-openssl = "0.10.35"
 pretty_assertions = "0.7.2"
 reqwest = "0.11.3"
 sha2 = "0.9.5"

--- a/lnd-test-context/src/lib.rs
+++ b/lnd-test-context/src/lib.rs
@@ -1,8 +1,6 @@
 use crate::owned_child::{CommandExt, OwnedChild};
 use cradle::*;
 use hex_literal::hex;
-use lnd_client::Client;
-use openssl::x509::X509;
 use pretty_assertions::assert_eq;
 use sha2::{Digest, Sha256};
 use std::{
@@ -261,22 +259,6 @@ impl LndTestContext {
 
   pub fn cert_path(&self) -> PathBuf {
     self.lnd_dir().join("tls.cert")
-  }
-
-  pub async fn client_with_cert(&self, cert: &str) -> Client {
-    Client::new(
-      format!("localhost:{}", self.lnd_rpc_port).parse().unwrap(),
-      Some(X509::from_pem(cert.as_bytes()).unwrap()),
-      Some(tokio::fs::read(self.invoice_macaroon_path()).await.unwrap()),
-    )
-    .await
-    .unwrap()
-  }
-
-  pub async fn client(&self) -> Client {
-    self
-      .client_with_cert(&fs::read_to_string(self.cert_path()).unwrap())
-      .await
   }
 }
 


### PR DESCRIPTION
- Remove debug flags from development builds
- Avoid cyclical dependencies between lnd-test-context and lnd-client
