### PR TITLE
Improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ paid: false
 
 Currently, `agora` charges the low low price of 1,000 satoshis for all paid files.
 
+## Development Agora Instances
+
+There are Agora instances accessible at [agora.download](http://agora.download) and [test.agora.download](http://test.agora.download). [agora.download](http://agora.download) operates on the Bitcoin mainnet, and the invoices it generates can be paid with any mainnet Lightning Network wallet. [http://test.agora.download](http://test.agora.download) operates on the Bitcoin testnet, and the invoices it generates can only be paid with a testnet Lightning Network wallet, for example, [htlc.me](https://htlc.me).
+
 ## Development
 
 You can run the tests locally with `cargo test`.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,78 @@ Currently, `agora` charges the low low price of 1,000 satoshis for all paid file
 
 ## Development Agora Instances
 
-There are Agora instances accessible at [agora.download](http://agora.download) and [test.agora.download](http://test.agora.download). [agora.download](http://agora.download) operates on the Bitcoin mainnet, and the invoices it generates can be paid with any mainnet Lightning Network wallet. [http://test.agora.download](http://test.agora.download) operates on the Bitcoin testnet, and the invoices it generates can only be paid with a testnet Lightning Network wallet, for example, [htlc.me](https://htlc.me).
+There are Agora instances accessible at [agora.download](http://agora.download) and [test.agora.download](http://test.agora.download).
+[agora.download](http://agora.download) operates on the Bitcoin mainnet, and the invoices it generates can be paid with any mainnet Lightning Network wallet.
+[http://test.agora.download](http://test.agora.download) operates on the Bitcoin testnet, and the invoices it generates can only be paid with a testnet Lightning Network wallet, for example, [htlc.me](https://htlc.me/).
+
+## Agora Instance Setup and Operation
+
+### Setting up a Bitcoin and Lightning Node
+
+Setting up Lightning node, and a Bitcoin node to go with it, is a complex topic, and many different approaches are possible.
+An excellent guide to setting up a Lightning Network node on Linux is available [here](https://stopanddecrypt.medium.com/a-complete-beginners-guide-to-installing-a-bitcoin-full-node-on-linux-2021-edition-46bf20fbe8ff), and a companion guide to setting up a Bitcoin node, to supply the Lightning Network node with information about the blockhain, is [here](https://stopanddecrypt.medium.com/a-complete-beginners-guide-to-installing-a-lightning-node-on-linux-2021-edition-ece227cfc35d).
+
+### Processing Payments with Agora
+
+In order for your Agora instance to receive payments, not only will it need to be connected to an LND node, but that LND node must have sufficient *inbound liquidity*.
+
+Liquidity management is one of the most complicated aspects of the Lightning Network, and certainly one of the most counter-intuitive.
+
+The basic primitive that makes up the Lightning Network is the "payment channel", commonly referred to as just a "channel".
+A channel is between two Lightning Network nodes, has a fixed capacity, is opened by making a on-chain Bitcoin transaction, and is closed by making an on-chain Bitcoin transaction.
+
+While the channel is open, the two parties to the channel can make payments between themselves, but do not have to publish a Bitcoin transaction for each one of these payments.
+They only have to publish a Bitcoin transaction when they want to close the channel, which nets-out the intermediate transactions made since it was opened.
+
+As a concrete example, let's say Alice and Bob open a channel, with Alice contributing 1 BTC when the channel is opened, and Bob contributing 0 BTC. Initially, their balances on the channel are:
+
+```
+Alice: 1 BTC
+Bob:   0 BTC
+```
+
+In this state, Alice can send a 0.1 BTC payment to bob, and the channel balances will be:
+
+```
+Alice: 0.9 BTC
+Bob:   0.1 BTC
+```
+
+Alice and Bob can send each other money, but only up to the amount that they have in the channel.
+At this point, Alice can send Bob up to 0.9 BTC, and Bob can send Alice up to 0.1 BTC.
+
+However, at the very beginning, when Bob's balance was 0 BTC, he could not have sent money to Alice.
+Due to a lack of inbound liquidity, which is, quite simply, money on the other side of a channel, which can be sent to you.
+
+This is an aspect of the Lightning Network that is very different from other payment systems, and from on-chain Bitcoin payments.
+You must arrange to have sufficient inbound liquidity to receive payments.
+
+A question you might ask is, *What if I just want to assume that the customer is good for the money and queue it up myself for settlement once I have the liquidity to spare?*
+
+Let's imagine that we were in the initial state, Alice had 1 BTC in the channel, Bob 0 BTC, and Alice let Bob make a payment to her of 1 BTC. The new balance would be:
+
+```
+Alice:  2 BTC
+Bob:   -1 BTC
+```
+
+However! When a Lightning Network channel is closed, you divide up the funds from the funding transaction between the parties to the channel.
+The channel was funded with an on-chain Bitcoin transaction of 1 BTC, so there is no way to pay out 2 BTC to Alice from the initial funding transaction.
+Since both parties to a payment channel can close the channel at any time, Alice would be trusting Bob to keep the channel open until he no longer had a negative balance.
+This is not scalable or secure, and avoiding the need for trust is the whole purpose of the Lightning Network in the first place, otherwise we could all just trade unenforceable IOUs back and forth.
+
+Inbound liquidity can be sourced in a number of ways, and [in-development proposals](https://github.com/lightningnetwork/lightning-rfc/pull/878) should make it even easier in the future. For now, we recomment purchasing inbound liquidity from [Bitrefill](https://www.bitrefill.com/buy/lightning-channel/). Bitrefill offers a service where a Lightning Node operator can pay Bitrefill to open a channel with that operator's Lightning Node. The operator pays Bitrefill a small amount of bitcoin and receives a channel with a much greater amount of inbound liquidity in return.
+
+### Paying Agora Invoices
+
+Agora invoices can be paid with a Lightning Network wallet.
+Popular wallets include:
+
+- [Wallet of Satoshi](https://www.walletofsatoshi.com/), a hosted wallet for Android and iOS.
+- [Strike](https://strike.me/), a hosted wallet for Android, iOS, and Google Chrome.
+- [Muun](https://muun.com/), a self-custodial wallet for iOS and Android.
+- [Breez](https://breez.technology/), a self-custodial wallet for iOS and Android.
+- [River Financial](https://river.com/), a Bitcoin financial services platform with the ability to buy and sell bitcoin for USD, and make and receive Lightning Payments, for the web, iOS, and Android.
 
 ## Development
 


### PR DESCRIPTION
I added a bunch of what seems like useful information to the readme, much of it cribbed from a [comment I made on HN](https://news.ycombinator.com/item?id=28111417).

We could think about making an operator's manual type document, which we could build with [mdbook](https://github.com/rust-lang/mdBook), but I put it in the readme for now. I don't actually think having a super long readme is that much of a problem, but it might get unweidly.