### PR TITLE
Fix publish script

### DIFF
--- a/bin/publish/src/main.rs
+++ b/bin/publish/src/main.rs
@@ -47,18 +47,6 @@ fn main() {
     .unwrap()
     .version;
 
-  if arguments.publish_agora_lnd_client {
-    (
-      "cargo",
-      "publish",
-      "--dry-run",
-      CurrentDir("agora-lnd-client"),
-    )
-      .run_unit();
-  }
-
-  ("cargo", "publish", "--dry-run").run_unit();
-
   (
     "git",
     "tag",


### PR DESCRIPTION
The publish script doesn't work if `agora-lnd-client` needs to be published, since the main crate dry run publish will fail if the version of `agora-lnd-client` on crates.io.

This PR removes the dry runs. We could do something fancier, but maybe we should just do the simple thing now, and wait for someone else to write a good `cargo` command that publishes workspaces.