### PR TITLE
Add link to invoice page to access file

### DIFF
--- a/src/files.rs
+++ b/src/files.rs
@@ -325,22 +325,43 @@ impl Files {
       }
       _ => {
         let qr_code_url = format!("/invoice/{}.svg", hex::encode(invoice.r_hash));
+        let filename = invoice.memo;
         Ok(html::wrap_body(html! {
           div class="invoice" {
             div class="label" {
               (format!("Lightning Payment Request for {} to access ", value))
               span class="filename" {
-                  (invoice.memo)
+                  (filename)
               }
               ":"
             }
             div class="payment-request" {
               (invoice.payment_request)
             }
-            a class="payment-link" href={"lightning:" (invoice.payment_request)} {
-              "Open in wallet"
+            div class="links" {
+              a class="payment-link" href={"lightning:" (invoice.payment_request)} {
+                "Open invoice in wallet"
+              }
+              a class="reload-link" href=(request.uri()) {
+                "Access file"
+              }
             }
             img class="qr-code" alt="Lightning Network Invoice QR Code" src=(qr_code_url);
+          }
+          div class="instructions" {
+            "To access " (filename) ":"
+            ol {
+              li {
+                "Pay the invoice for " (value) " above "
+                "with your Lightning Network wallet by "
+                "scanning the QR code, "
+                "copying the payment request string, or "
+                "clicking the \"Open in wallet\" link."
+              }
+              li {
+                "Click the \"Access file\" link or reload the page."
+              }
+            }
           }
         }))
       }

--- a/src/files.rs
+++ b/src/files.rs
@@ -360,7 +360,7 @@ impl Files {
                 "with your Lightning Network wallet by "
                 "scanning the QR code, "
                 "copying the payment request string, or "
-                "clicking the \"Open in wallet\" link."
+                "clicking the \"Open invoice in wallet\" link."
               }
               li {
                 "Click the \"Access file\" link or reload the page."

--- a/src/files.rs
+++ b/src/files.rs
@@ -329,7 +329,7 @@ impl Files {
         Ok(html::wrap_body(html! {
           div class="invoice" {
             div class="label" {
-              (format!("Lightning Payment Request for {} to access ", value))
+              "Lightning Payment Request for " (value) " to access "
               span class="filename" {
                   (filename)
               }
@@ -349,7 +349,11 @@ impl Files {
             img class="qr-code" alt="Lightning Network Invoice QR Code" src=(qr_code_url);
           }
           div class="instructions" {
-            "To access " (filename) ":"
+            "To access "
+            span class="filename" {
+                (filename)
+            }
+            ":"
             ol {
               li {
                 "Pay the invoice for " (value) " above "

--- a/src/tests/slow_tests.rs
+++ b/src/tests/slow_tests.rs
@@ -151,7 +151,12 @@ fn paying_invoice_allows_downloading_file() {
     guard_unwrap!(let &[payment_request] = css_select(&html, ".payment-request").as_slice());
     let payment_request = payment_request.inner_html();
     receiver.fulfill_own_payment_request(&payment_request).await;
-    assert_eq!(text(&invoice_url).await, "precious content");
+    guard_unwrap!(let &[reload_link] = css_select(&html, ".reload-link").as_slice());
+    let link = reload_link.value().attr("href").unwrap();
+    assert_eq!(
+      text(&invoice_url.join(link).unwrap()).await,
+      "precious content"
+    );
   });
 }
 

--- a/src/tests/slow_tests.rs
+++ b/src/tests/slow_tests.rs
@@ -152,9 +152,9 @@ fn paying_invoice_allows_downloading_file() {
     let payment_request = payment_request.inner_html();
     receiver.fulfill_own_payment_request(&payment_request).await;
     guard_unwrap!(let &[reload_link] = css_select(&html, ".reload-link").as_slice());
-    let link = reload_link.value().attr("href").unwrap();
+    let reload_link = reload_link.value().attr("href").unwrap();
     assert_eq!(
-      text(&invoice_url.join(link).unwrap()).await,
+      text(&invoice_url.join(reload_link).unwrap()).await,
       "precious content"
     );
   });

--- a/static/index.css
+++ b/static/index.css
@@ -64,13 +64,21 @@ body {
   user-select: all;
 }
 
-.invoice > .payment-link {
+.invoice > .links {
   display: block;
   text-align: center;
+}
+
+.invoice > .links > a {
+  padding: 1em;
 }
 
 .invoice > .qr-code {
   display: block;
   margin: auto;
   max-width: 400px;
+}
+
+.instructions {
+  padding-top: 0.5em;
 }

--- a/static/index.css
+++ b/static/index.css
@@ -54,10 +54,6 @@ body {
   white-space: nowrap;
 }
 
-.invoice > .label > .filename {
-  font-family: "Courier New", Courier, monospace;
-}
-
 .invoice > .payment-request {
   font-family: "Courier New", Courier, monospace;
   overflow-wrap: anywhere;
@@ -81,4 +77,8 @@ body {
 
 .instructions {
   padding-top: 0.5em;
+}
+
+.filename {
+  font-family: "Courier New", Courier, monospace;
 }


### PR DESCRIPTION
This PR adds a link `Access file` to the invoice page to access the file after paying the invoice.

It also adds some instructions on the bottom of the invoice page to explain the process.

It's meant as a partial solution to #142.

![image](https://user-images.githubusercontent.com/402539/130521061-aad2a95a-3d9c-43ff-9c56-8b7b72d0a04b.png)
