### PR TITLE
Use imperative mood and value name in help

### DIFF
--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -27,7 +27,7 @@ pub(crate) struct Arguments {
   pub(crate) lnd_rpc_cert_path: Option<PathBuf>,
   #[structopt(
     long,
-    help = "Read LND's gRPC macaroon from <lnd-rpc-macaroon-path>. Needed if LND requires macaroon authentication. The macaroon has to include permissions for creating and querying invoices. By default LND writes its invoice macaroon to `~/.lnd/data/chain/bitcoin/mainnet/invoice.macaroon`.",
+    help = "Read LND gRPC macaroon from <lnd-rpc-macaroon-path>. Needed if LND requires macaroon authentication. The macaroon must include permissions for creating and querying invoices. By default LND writes its invoice macaroon to `~/.lnd/data/chain/bitcoin/mainnet/invoice.macaroon`.",
     requires = "lnd-rpc-authority"
   )]
   pub(crate) lnd_rpc_macaroon_path: Option<PathBuf>,

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -4,26 +4,30 @@ use structopt::StructOpt;
 
 #[derive(StructOpt)]
 pub(crate) struct Arguments {
-  #[structopt(long, default_value = "0.0.0.0", help = "Address to listen on")]
+  #[structopt(
+    long,
+    default_value = "0.0.0.0",
+    help = "Listen on <address> for incoming requests"
+  )]
   pub(crate) address: String,
-  #[structopt(long, help = "Directory of files to serve")]
+  #[structopt(long, help = "Serve files from <directory>")]
   pub(crate) directory: PathBuf,
-  #[structopt(long, help = "Port to listen on for incoming HTTP requests")]
+  #[structopt(long, help = "Listen on <port> for incoming HTTP requests")]
   pub(crate) port: u16,
   #[structopt(
     long,
-    help = "Host and port of the LND gRPC server. By default a locally running LND instance will expose its gRPC API on `localhost:10009`."
+    help = "Connect to LND gRPC server with host and port <lnd-rpc-authority>. By default a locally running LND instance will expose its gRPC API on `localhost:10009`."
   )]
   pub(crate) lnd_rpc_authority: Option<Authority>,
   #[structopt(
     long,
-    help = "Path to LND's TLS certificate. Needed if LND uses a self-signed certificate. By default LND writes its TLS certificate to `~/.lnd/tls.cert`.",
+    help = "Read LND's TLS certificate from <lnd-rpc-cert-path>. Needed if LND uses a self-signed certificate. By default LND writes its TLS certificate to `~/.lnd/tls.cert`.",
     requires = "lnd-rpc-authority"
   )]
   pub(crate) lnd_rpc_cert_path: Option<PathBuf>,
   #[structopt(
     long,
-    help = "Path to an LND gRPC macaroon, that allows creating and querying invoices. Needed if LND requires macaroon authentication. By default LND writes its invoice macaroon to `~/.lnd/data/chain/bitcoin/mainnet/invoice.macaroon`.",
+    help = "Read LND's gRPC macaroon from <lnd-rpc-macaroon-path>, that allows creating and querying invoices. Needed if LND requires macaroon authentication. By default LND writes its invoice macaroon to `~/.lnd/data/chain/bitcoin/mainnet/invoice.macaroon`.",
     requires = "lnd-rpc-authority"
   )]
   pub(crate) lnd_rpc_macaroon_path: Option<PathBuf>,

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -27,7 +27,7 @@ pub(crate) struct Arguments {
   pub(crate) lnd_rpc_cert_path: Option<PathBuf>,
   #[structopt(
     long,
-    help = "Read LND's gRPC macaroon from <lnd-rpc-macaroon-path>, that allows creating and querying invoices. Needed if LND requires macaroon authentication. By default LND writes its invoice macaroon to `~/.lnd/data/chain/bitcoin/mainnet/invoice.macaroon`.",
+    help = "Read LND's gRPC macaroon from <lnd-rpc-macaroon-path>. Needed if LND requires macaroon authentication. The macaroon has to include permissions for creating and querying invoices. By default LND writes its invoice macaroon to `~/.lnd/data/chain/bitcoin/mainnet/invoice.macaroon`.",
     requires = "lnd-rpc-authority"
   )]
   pub(crate) lnd_rpc_macaroon_path: Option<PathBuf>,


### PR DESCRIPTION
This changes the help flags to use the imperative mood, as well as mention the names of flag values.

I like this way of phrasing help messages, it avoids awkward alternative constructions like "X of" and "X to" at the beginning of help messages, the imperative mood feels like the user is commanding the program, and mentioning the flag value by name is clearer.

What do you think?