### PR TITLE
Deduplicate common imports in common.rs

### DIFF
--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -1,9 +1,6 @@
-use http::uri::Authority;
-use std::path::PathBuf;
-use structopt::{
-  clap::{AppSettings, ArgGroup},
-  StructOpt,
-};
+use crate::common::*;
+
+use structopt::clap::{AppSettings, ArgGroup};
 
 #[derive(Debug, StructOpt)]
 #[structopt(

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -1,5 +1,4 @@
 use crate::common::*;
-
 use structopt::clap::{AppSettings, ArgGroup};
 
 #[derive(Debug, StructOpt)]

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,0 +1,64 @@
+pub(crate) use std::{
+  convert::Infallible,
+  env,
+  ffi::OsString,
+  fs::{self, FileType},
+  future,
+  future::Future,
+  io::{self, Write},
+  mem::MaybeUninit,
+  net::{SocketAddr, ToSocketAddrs},
+  path::{Path, PathBuf},
+  pin::Pin,
+  str,
+  sync::Arc,
+  task::{Context, Poll},
+  time::Duration,
+};
+
+pub(crate) use ::{
+  agora_lnd_client::Millisatoshi,
+  futures::{
+    future::{BoxFuture, OptionFuture},
+    FutureExt, Stream, StreamExt,
+  },
+  http::uri::Authority,
+  hyper::{
+    header::{self, HeaderValue},
+    server::conn::AddrIncoming,
+    service::Service,
+    Body, Request, Response, StatusCode,
+  },
+  lexiclean::Lexiclean,
+  maud::Markup,
+  serde::Deserialize,
+  snafu::{IntoError, ResultExt},
+  structopt::StructOpt,
+  tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    task,
+  },
+};
+
+pub(crate) use crate::{
+  arguments::Arguments,
+  config::Config,
+  environment::Environment,
+  error::{self, Error, Result},
+  error_page, html,
+  https_redirect_service::HttpsRedirectService,
+  https_request_handler::HttpsRequestHandler,
+  input_path::InputPath,
+  redirect::redirect,
+  request_handler::RequestHandler,
+  server::Server,
+  stderr::Stderr,
+};
+
+#[cfg(test)]
+mod test {
+  pub(crate) use tempfile::TempDir;
+}
+
+#[cfg(test)]
+pub(crate) use test::*;

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,21 +1,17 @@
-pub(crate) use std::{
-  convert::Infallible,
-  env,
-  ffi::OsString,
-  fs::{self, FileType},
-  future,
-  future::Future,
-  io::{self, Write},
-  mem::MaybeUninit,
-  net::{SocketAddr, ToSocketAddrs},
-  path::{Path, PathBuf},
-  pin::Pin,
-  str,
-  sync::Arc,
-  task::{Context, Poll},
-  time::Duration,
+pub(crate) use crate::{
+  arguments::Arguments,
+  config::Config,
+  environment::Environment,
+  error::{self, Error, Result},
+  error_page, html,
+  https_redirect_service::HttpsRedirectService,
+  https_request_handler::HttpsRequestHandler,
+  input_path::InputPath,
+  redirect::redirect,
+  request_handler::RequestHandler,
+  server::Server,
+  stderr::Stderr,
 };
-
 pub(crate) use ::{
   agora_lnd_client::Millisatoshi,
   futures::{
@@ -33,32 +29,28 @@ pub(crate) use ::{
   maud::Markup,
   serde::Deserialize,
   snafu::{IntoError, ResultExt},
-  structopt::StructOpt,
-  tokio::{
-    io::{AsyncReadExt, AsyncWriteExt},
-    task,
+  std::{
+    convert::Infallible,
+    env,
+    ffi::OsString,
+    fs::{self, FileType},
+    future,
+    io::{self, Write},
+    mem::MaybeUninit,
+    net::{SocketAddr, ToSocketAddrs},
+    path::{Path, PathBuf},
+    pin::Pin,
+    str,
+    sync::Arc,
+    task::{Context, Poll},
   },
-};
-
-pub(crate) use crate::{
-  arguments::Arguments,
-  config::Config,
-  environment::Environment,
-  error::{self, Error, Result},
-  error_page, html,
-  https_redirect_service::HttpsRedirectService,
-  https_request_handler::HttpsRequestHandler,
-  input_path::InputPath,
-  redirect::redirect,
-  request_handler::RequestHandler,
-  server::Server,
-  stderr::Stderr,
+  structopt::StructOpt,
+  tokio::task,
 };
 
 #[cfg(test)]
-mod test {
-  pub(crate) use tempfile::TempDir;
-}
-
-#[cfg(test)]
-pub(crate) use test::*;
+pub(crate) use ::{
+  std::{future::Future, time::Duration},
+  tempfile::TempDir,
+  tokio::io::{AsyncReadExt, AsyncWriteExt},
+};

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,4 @@
-use crate::error::{self, Error, Result};
-use agora_lnd_client::Millisatoshi;
-use serde::Deserialize;
-use snafu::{IntoError, ResultExt};
-use std::{fs, io, path::Path};
+use crate::common::*;
 
 #[derive(PartialEq, Debug, Default, Deserialize)]
 #[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
@@ -55,9 +51,7 @@ impl Config {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::error::Error;
   use pretty_assertions::assert_eq;
-  use tempfile::TempDir;
   use unindent::Unindent;
 
   #[test]

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -1,14 +1,4 @@
-use crate::{
-  arguments::Arguments,
-  error::{self, Result},
-  stderr::Stderr,
-};
-use snafu::ResultExt;
-use std::{env, ffi::OsString, path::PathBuf};
-use structopt::StructOpt;
-
-#[cfg(test)]
-use tempfile::TempDir;
+use crate::common::*;
 
 pub(crate) struct Environment {
   pub(crate) arguments: Vec<OsString>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,4 @@
 use crate::common::*;
-
 use color_backtrace::BacktracePrinter;
 use snafu::{ErrorCompat, Snafu};
 use std::{path::MAIN_SEPARATOR, str::Utf8Error};

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,14 +1,8 @@
-use crate::input_path::InputPath;
+use crate::common::*;
+
 use color_backtrace::BacktracePrinter;
-use hyper::StatusCode;
 use snafu::{ErrorCompat, Snafu};
-use std::{
-  fmt::Debug,
-  io,
-  net::SocketAddr,
-  path::{PathBuf, MAIN_SEPARATOR},
-  str::Utf8Error,
-};
+use std::{path::MAIN_SEPARATOR, str::Utf8Error};
 use structopt::clap;
 use termcolor::WriteColor;
 use tokio::task::JoinError;

--- a/src/error_page.rs
+++ b/src/error_page.rs
@@ -1,11 +1,6 @@
-use crate::{
-  error::{Error, Result},
-  html,
-  stderr::Stderr,
-};
-use hyper::{Body, Response};
+use crate::common::*;
+
 use maud::html;
-use std::{convert::Infallible, io::Write};
 
 pub(crate) fn map_error(
   mut stderr: Stderr,

--- a/src/error_page.rs
+++ b/src/error_page.rs
@@ -1,5 +1,4 @@
 use crate::common::*;
-
 use maud::html;
 
 pub(crate) fn map_error(

--- a/src/file_stream.rs
+++ b/src/file_stream.rs
@@ -1,5 +1,4 @@
 use crate::common::*;
-
 use hyper::body::Bytes;
 use pin_project::pin_project;
 use tokio::{

--- a/src/file_stream.rs
+++ b/src/file_stream.rs
@@ -1,16 +1,7 @@
-use crate::{
-  error::{Error, Result},
-  input_path::InputPath,
-};
-use futures::Stream;
+use crate::common::*;
+
 use hyper::body::Bytes;
 use pin_project::pin_project;
-use snafu::ResultExt;
-use std::{
-  mem::MaybeUninit,
-  pin::Pin,
-  task::{self, Poll},
-};
 use tokio::{
   fs::File,
   io::{AsyncRead, ReadBuf},
@@ -37,7 +28,7 @@ impl FileStream {
 impl Stream for FileStream {
   type Item = Result<Bytes>;
 
-  fn poll_next(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
+  fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
     let data = &mut [MaybeUninit::uninit(); 8 * 1024];
     let mut buf = ReadBuf::uninit(data);
 

--- a/src/files.rs
+++ b/src/files.rs
@@ -1,24 +1,9 @@
-use crate::{
-  config::Config,
-  error::{self, Error, Result},
-  file_stream::FileStream,
-  html,
-  input_path::InputPath,
-  redirect::redirect,
-};
+use crate::common::*;
+
+use crate::file_stream::FileStream;
 use agora_lnd_client::lnrpc::invoice::InvoiceState;
-use hyper::{header, Body, Request, Response, StatusCode};
-use lexiclean::Lexiclean;
-use maud::{html, Markup};
+use maud::html;
 use percent_encoding::{AsciiSet, NON_ALPHANUMERIC};
-use snafu::{IntoError, ResultExt};
-use std::{
-  ffi::OsString,
-  fmt::Debug,
-  fs::{self, FileType},
-  io,
-  path::Path,
-};
 
 #[derive(Clone, Debug)]
 pub(crate) struct Files {

--- a/src/files.rs
+++ b/src/files.rs
@@ -1,6 +1,4 @@
-use crate::common::*;
-
-use crate::file_stream::FileStream;
+use crate::{common::*, file_stream::FileStream};
 use agora_lnd_client::lnrpc::invoice::InvoiceState;
 use maud::html;
 use percent_encoding::{AsciiSet, NON_ALPHANUMERIC};

--- a/src/html.rs
+++ b/src/html.rs
@@ -1,5 +1,4 @@
 use crate::common::*;
-
 use maud::{html, DOCTYPE};
 
 pub(crate) fn wrap_body(body: Markup) -> Response<Body> {

--- a/src/html.rs
+++ b/src/html.rs
@@ -1,5 +1,6 @@
-use hyper::{header, Body, Response};
-use maud::{html, Markup, DOCTYPE};
+use crate::common::*;
+
+use maud::{html, DOCTYPE};
 
 pub(crate) fn wrap_body(body: Markup) -> Response<Body> {
   let html = html! {

--- a/src/https_redirect_service.rs
+++ b/src/https_redirect_service.rs
@@ -1,24 +1,6 @@
-use crate::{
-  arguments::Arguments,
-  environment::Environment,
-  error::{self, Result},
-  error_page,
-  https_request_handler::HttpsRequestHandler,
-  redirect::redirect,
-  stderr::Stderr,
-};
-use http::uri::Authority;
-use hyper::server::conn::AddrIncoming;
-use hyper::{header, Body, Request, Response, StatusCode};
-use snafu::ResultExt;
-use std::{
-  convert::Infallible,
-  future,
-  net::ToSocketAddrs,
-  task::{Context, Poll},
-};
+use crate::common::*;
+
 use tower::make::Shared;
-use tower::Service;
 
 #[derive(Clone)]
 pub(crate) struct HttpsRedirectService {

--- a/src/https_redirect_service.rs
+++ b/src/https_redirect_service.rs
@@ -1,5 +1,4 @@
 use crate::common::*;
-
 use tower::make::Shared;
 
 #[derive(Clone)]

--- a/src/https_request_handler.rs
+++ b/src/https_request_handler.rs
@@ -1,23 +1,10 @@
-use crate::{
-  arguments::Arguments,
-  environment::Environment,
-  error::{self, Result},
-  request_handler::RequestHandler,
-};
-use futures::StreamExt;
+use crate::common::*;
+
 use hyper::server::conn::Http;
 use rustls_acme::{
   acme::{ACME_TLS_ALPN_NAME, LETS_ENCRYPT_PRODUCTION_DIRECTORY, LETS_ENCRYPT_STAGING_DIRECTORY},
   ResolvesServerCertUsingAcme,
 };
-use snafu::ResultExt;
-use std::{
-  io::Write,
-  net::ToSocketAddrs,
-  path::{Path, PathBuf},
-  sync::Arc,
-};
-use tokio::task;
 use tokio_rustls::{
   rustls::{NoClientAuth, ServerConfig, Session},
   server::TlsStream,

--- a/src/input_path.rs
+++ b/src/input_path.rs
@@ -1,10 +1,7 @@
-use crate::{
-  environment::Environment,
-  error::{self, Error, Result},
-};
+use crate::common::*;
+
 use mime_guess::MimeGuess;
-use std::fmt::Debug;
-use std::path::{Component, Path, PathBuf};
+use std::path::Component;
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct InputPath {

--- a/src/input_path.rs
+++ b/src/input_path.rs
@@ -1,5 +1,4 @@
 use crate::common::*;
-
 use mime_guess::MimeGuess;
 use std::path::Component;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
-use crate::{error::Result, server::Server};
-use environment::Environment;
+use crate::common::*;
 
 #[cfg(test)]
 #[macro_use]
 mod test_utils;
 
 mod arguments;
+mod common;
 mod config;
 mod environment;
 mod error;

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -1,5 +1,4 @@
-use crate::error::{Error, Result};
-use hyper::{header, Body, Response, StatusCode};
+use crate::common::*;
 
 pub(crate) fn redirect(location: String) -> Result<Response<Body>> {
   Response::builder()

--- a/src/request_handler.rs
+++ b/src/request_handler.rs
@@ -1,6 +1,4 @@
-use crate::common::*;
-
-use crate::{error_page, files::Files, static_assets::StaticAssets};
+use crate::{common::*, error_page, files::Files, static_assets::StaticAssets};
 
 #[derive(Clone)]
 pub(crate) struct RequestHandler {

--- a/src/request_handler.rs
+++ b/src/request_handler.rs
@@ -1,25 +1,6 @@
-use crate::{
-  environment::Environment,
-  error::{self, Error, Result},
-  error_page,
-  files::Files,
-  input_path::InputPath,
-  redirect::redirect,
-  static_assets::StaticAssets,
-  stderr::Stderr,
-};
-use futures::{future::BoxFuture, FutureExt};
-use hyper::{
-  header::{self, HeaderValue},
-  service::Service,
-  Body, Request, Response,
-};
-use snafu::ResultExt;
-use std::{
-  convert::Infallible,
-  path::Path,
-  task::{self, Poll},
-};
+use crate::common::*;
+
+use crate::{error_page, files::Files, static_assets::StaticAssets};
 
 #[derive(Clone)]
 pub(crate) struct RequestHandler {
@@ -104,7 +85,7 @@ impl Service<Request<Body>> for RequestHandler {
   type Error = Infallible;
   type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
-  fn poll_ready(&mut self, _cx: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+  fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
     Ok(()).into()
   }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,16 +1,6 @@
-use crate::{
-  arguments::Arguments,
-  environment::Environment,
-  error::{self, Result},
-  https_redirect_service::HttpsRedirectService,
-  https_request_handler::HttpsRequestHandler,
-  request_handler::RequestHandler,
-};
-use futures::{future::OptionFuture, FutureExt};
-use hyper::server::conn::AddrIncoming;
+use crate::common::*;
+
 use openssl::x509::X509;
-use snafu::ResultExt;
-use std::{io::Write, net::ToSocketAddrs};
 use tower::make::Shared;
 
 pub(crate) struct Server {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,4 @@
 use crate::common::*;
-
 use openssl::x509::X509;
 use tower::make::Shared;
 

--- a/src/static_assets.rs
+++ b/src/static_assets.rs
@@ -1,5 +1,4 @@
 use crate::common::*;
-
 use rust_embed::RustEmbed;
 
 #[derive(RustEmbed)]

--- a/src/static_assets.rs
+++ b/src/static_assets.rs
@@ -1,5 +1,5 @@
-use crate::error::{self, Error, Result};
-use hyper::{header, Body, Response};
+use crate::common::*;
+
 use rust_embed::RustEmbed;
 
 #[derive(RustEmbed)]

--- a/src/stderr.rs
+++ b/src/stderr.rs
@@ -1,5 +1,4 @@
 use crate::common::*;
-
 use termcolor::{ColorSpec, WriteColor};
 
 #[cfg(test)]

--- a/src/stderr.rs
+++ b/src/stderr.rs
@@ -1,8 +1,9 @@
-use std::io::{self, Write};
+use crate::common::*;
+
 use termcolor::{ColorSpec, WriteColor};
 
 #[cfg(test)]
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 #[derive(Clone)]
 pub(crate) enum Stderr {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,11 +1,9 @@
-use crate::{
-  environment::Environment,
-  server::{Server, TestContext},
-};
+use crate::common::*;
+
+use crate::server::TestContext;
 #[cfg(feature = "slow-tests")]
 use lnd_test_context::LndTestContext;
-use std::{ffi::OsString, future::Future, panic};
-use tokio::task;
+use std::panic;
 
 macro_rules! assert_matches {
   ($expression:expr, $( $pattern:pat )|+ $( if $guard:expr )?) => {
@@ -100,8 +98,8 @@ where
       let server = Server::setup(environment).await.unwrap();
       let test_context = server.test_context(environment);
       let server_join_handle = tokio::spawn(async { server.run().await.unwrap() });
-      let test_result = task::LocalSet::new()
-        .run_until(async move { task::spawn_local(test_function(test_context)).await })
+      let test_result = tokio::task::LocalSet::new()
+        .run_until(async move { tokio::task::spawn_local(test_function(test_context)).await })
         .await;
       if let Err(test_join_error) = test_result {
         eprintln!("stderr from server: {}", environment.stderr.contents());

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,5 +1,4 @@
 use crate::common::*;
-
 use crate::server::TestContext;
 #[cfg(feature = "slow-tests")]
 use lnd_test_context::LndTestContext;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,5 @@
-use crate::common::*;
-
 use crate::{
+  common::*,
   server::TestContext,
   test_utils::{
     assert_contains, assert_not_contains, test, test_with_arguments, test_with_environment,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,23 +1,17 @@
+use crate::common::*;
+
 use crate::{
-  environment::Environment,
-  error::Error,
-  server::{Server, TestContext},
+  server::TestContext,
   test_utils::{
     assert_contains, assert_not_contains, test, test_with_arguments, test_with_environment,
   },
 };
 use guard::guard_unwrap;
-use hyper::{header, StatusCode};
-use lexiclean::Lexiclean;
 use pretty_assertions::assert_eq;
 use reqwest::{redirect::Policy, Certificate, Client, ClientBuilder, Url};
 use scraper::{ElementRef, Html, Selector};
-use std::{fs, net::TcpListener, path::Path, path::MAIN_SEPARATOR, str, time::Duration};
-use tempfile::TempDir;
-use tokio::{
-  io::{AsyncReadExt, AsyncWriteExt},
-  net::TcpStream,
-};
+use std::{net::TcpListener, path::MAIN_SEPARATOR};
+use tokio::net::TcpStream;
 
 #[cfg(feature = "slow-tests")]
 mod browser_tests;

--- a/src/tests/browser_tests.rs
+++ b/src/tests/browser_tests.rs
@@ -1,12 +1,12 @@
+use crate::common::*;
+
 use crate::test_utils::test_with_lnd;
 use chromiumoxide::{
   browser::BrowserConfig,
   cdp::browser_protocol::browser::{PermissionDescriptor, PermissionSetting, SetPermissionParams},
 };
-use futures::StreamExt;
 use lnd_test_context::LndTestContext;
 use pretty_assertions::assert_eq;
-use tokio::task;
 
 struct Browser {
   inner: chromiumoxide::Browser,

--- a/src/tests/browser_tests.rs
+++ b/src/tests/browser_tests.rs
@@ -1,6 +1,4 @@
-use crate::common::*;
-
-use crate::test_utils::test_with_lnd;
+use crate::{common::*, test_utils::test_with_lnd};
 use chromiumoxide::{
   browser::BrowserConfig,
   cdp::browser_protocol::browser::{PermissionDescriptor, PermissionSetting, SetPermissionParams},

--- a/src/tests/slow_tests.rs
+++ b/src/tests/slow_tests.rs
@@ -1,5 +1,4 @@
 use super::*;
-
 use crate::test_utils::{assert_contains, test_with_arguments, test_with_lnd};
 use guard::guard_unwrap;
 use lnd_test_context::LndTestContext;

--- a/src/tests/slow_tests.rs
+++ b/src/tests/slow_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
+
 use crate::test_utils::{assert_contains, test_with_arguments, test_with_lnd};
 use guard::guard_unwrap;
-use hyper::{header, StatusCode};
 use lnd_test_context::LndTestContext;
 use pretty_assertions::assert_eq;
 use regex::Regex;


### PR DESCRIPTION
As I've been threatening to do, I deduplicated our imports, and put everything into `common.rs` that I thought would be reasonably unambiguous.