### PR TITLE
Use rustflags consistently on Windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["--codegen", "target-feature=+crt-static"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
-[target.x86_64-pc-windows-msvc]
+[build]
 rustflags = ["--codegen", "target-feature=+crt-static"]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,6 +72,15 @@ jobs:
         rustup target add ${{ matrix.target }}
         rustup default `cat rust-toolchain`-${{ matrix.target }}
 
+    - name: Package
+      id: package
+      if: startsWith(github.ref, 'refs/tags/')
+      env:
+        TARGET: ${{ matrix.target }}
+        REF: ${{ github.ref }}
+        OS: ${{ matrix.os }}
+      run: ./bin/package
+
     - name: Info
       run: |
         rustup --version
@@ -108,15 +117,6 @@ jobs:
         sudo apt-get update
         sudo apt-get install ripgrep
         ./bin/forbid
-
-    - name: Package
-      id: package
-      if: startsWith(github.ref, 'refs/tags/')
-      env:
-        TARGET: ${{ matrix.target }}
-        REF: ${{ github.ref }}
-        OS: ${{ matrix.os }}
-      run: ./bin/package
 
     - name: Prerelease Check
       id: is_prerelease

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,3 @@ test = false
 
 [features]
 slow-tests = []
-
-[target.x86_64-pc-windows-msvc]
-rustflags = ["--codegen", "target-feature=+crt-static"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,3 +108,6 @@ test = false
 
 [features]
 slow-tests = []
+
+[target.x86_64-pc-windows-msvc]
+rustflags = ["--codegen", "target-feature=+crt-static"]

--- a/bin/package
+++ b/bin/package
@@ -9,17 +9,12 @@ BIN=agora
 echo "Packaging $BIN $VERSION for $TARGET..."
 
 echo "Building $BIN..."
+cargo build --bin $BIN --target $TARGET --release
+EXECUTABLE=target/$TARGET/release/$BIN
 
-case $OS in
-  ubuntu-latest | macos-latest)
-    cargo build --bin $BIN --target $TARGET --release
-    EXECUTABLE=target/$TARGET/release/$BIN
-    ;;
-  windows-latest)
-    cargo rustc --bin $BIN --target $TARGET --release -- --codegen target-feature="+crt-static"
-    EXECUTABLE=target/$TARGET/release/$BIN.exe
-    ;;
-esac
+if [[ $OS == windows-latest ]]; then
+  EXECUTABLE=$EXECUTABLE.exe
+fi
 
 echo "Copying release files..."
 mkdir dist


### PR DESCRIPTION
I took the opportunity to clean up `bin/package` a little bit as well.

I pushed this as a tag to trigger an actions run, to check that this actually works: https://github.com/agora-org/agora/actions/runs/1322120956