### PR TITLE
Fix package script to work on branches

### DIFF
--- a/bin/package
+++ b/bin/package
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION=${REF#"refs/tags/"}
+VERSION=`basename $REF`
 DIST=`pwd`/dist
 BIN=agora
 
@@ -17,7 +17,7 @@ if [[ $OS == windows-latest ]]; then
 fi
 
 echo "Copying release files..."
-mkdir dist
+mkdir $DIST
 cp \
   $EXECUTABLE \
   Cargo.lock \


### PR DESCRIPTION
The package script [failed](https://github.com/agora-org/agora/actions/runs/1339388542) on master because it expects `github.ref` to be in the form `refs/tags/tag`, and on master it's `refs/heads/master`. This commit modifies the package script to use `$(basename $REF)`, which works for both.

I also pushed this to a tag, to make sure it still works for tags: https://github.com/agora-org/agora/actions/runs/1339570294