### PR TITLE
Use Swatinem/rust-cache

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,8 +62,6 @@ jobs:
         cargo --version
         cargo clippy --version
         cargo fmt --version
-        mkdir -p target
-        ls -l target
 
     - name: Check Lockfile
       run: |


### PR DESCRIPTION
- [x] What will happen to our LND and bitcoind downloads and checkouts? rust-cache doesn't seem to remove them, so I added an extra step to remove the source files and tarballs, which cuts down the size of the cache by around 200 MiB.