### PR TITLE
Add side margins

### DIFF
--- a/static/index.css
+++ b/static/index.css
@@ -1,3 +1,8 @@
+html {
+  margin-left: 1rem;
+  margin-right: 1rem;
+}
+
 body {
   font-family: sans-serif;
   margin-left: auto;


### PR DESCRIPTION
I noticed that content was smushed against the sides on small displays.

Before:

<img width="568" alt="Screen Shot 2021-10-21 at 1 49 37 AM" src="https://user-images.githubusercontent.com/1945/138244586-d400d165-7156-4429-ba9d-7ef8fd18f319.png">

After:

<img width="612" alt="Screen Shot 2021-10-21 at 1 49 46 AM" src="https://user-images.githubusercontent.com/1945/138244614-97f5af7b-086d-430b-bfe4-d0f97489f30a.png">

Everything is identical when the window is large.

I added it to the HTML because I think otherwise we would need another div, since we already have `auto` margins on our `body`.