### PR TITLE
Allow to offer dynamic script output for download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,7 @@ dependencies = [
  "bytes",
  "chromiumoxide",
  "color-backtrace",
+ "cradle 0.2.0",
  "env_logger 0.9.0",
  "executable-path",
  "form_urlencoded",
@@ -139,7 +140,7 @@ dependencies = [
 name = "agora-lnd-client"
 version = "0.0.2"
 dependencies = [
- "cradle",
+ "cradle 0.0.21",
  "hex",
  "hex-literal",
  "http",
@@ -828,6 +829,15 @@ name = "cradle"
 version = "0.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b1164a87f6f56a255b85adc678e3d6e46ca3ad9331b79461ac706fc783c103c"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "cradle"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9473b661a00f1ceccdba920e10a2c35b7c0a73c11c0b14c4d11d25195141d00d"
 dependencies = [
  "rustversion",
 ]
@@ -1902,7 +1912,7 @@ dependencies = [
 name = "lnd-test-context"
 version = "0.0.0"
 dependencies = [
- "cradle",
+ "cradle 0.0.21",
  "hex-literal",
  "lazy_static",
  "pretty_assertions 0.7.2",
@@ -2711,7 +2721,7 @@ name = "publish"
 version = "0.0.0"
 dependencies = [
  "cargo_metadata",
- "cradle",
+ "cradle 0.0.21",
  "structopt",
  "tempfile",
 ]
@@ -3892,8 +3902,10 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "once_cell",
  "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "tokio-macros",
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,11 @@ qrcodegen = "=1.6.0"
 rust-embed = "6.2.0"
 rustls-acme = "0.1.7"
 serde_yaml = "0.8.17"
+tempfile = "3.2.0"
 termcolor = "1.1.2"
 tokio-rustls = "0.22.0"
 tonic = "0.5.2"
+cradle = "0.2.0"
 
 [dependencies.agora-lnd-client]
 path = "agora-lnd-client"
@@ -60,7 +62,7 @@ features = ["wrap_help"]
 
 [dependencies.tokio]
 version = "1.5.0"
-features = ["rt", "rt-multi-thread", "macros", "fs"]
+features = ["rt", "rt-multi-thread", "macros", "fs", "process"]
 
 [dependencies.tokio-stream]
 version = "0.1.7"
@@ -83,7 +85,6 @@ pretty_assertions = "1.0.0"
 regex = "1.5.4"
 resvg = "0.15.0"
 scraper = "0.12.0"
-tempfile = "3.2.0"
 tiny-skia = "0.5.1"
 unindent = "0.1.7"
 usvg = "0.15.0"

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,6 @@
 pub(crate) use crate::{
   arguments::Arguments,
-  config::Config,
+  config::{Config, VirtualFile},
   environment::Environment,
   error::{self, Error, Result},
   error_page, html,

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,8 @@ use std::collections::BTreeMap;
 
 #[derive(PartialEq, Debug, Deserialize, Clone)]
 #[serde(tag = "type", deny_unknown_fields)]
-enum VirtualFile {
+pub(crate) enum VirtualFile {
+  #[allow(non_camel_case_types)]
   script { source: String },
 }
 
@@ -12,7 +13,7 @@ enum VirtualFile {
 pub(crate) struct Config {
   paid: Option<bool>,
   pub(crate) base_price: Option<Millisatoshi>,
-  files: BTreeMap<String, VirtualFile>,
+  pub(crate) files: BTreeMap<String, VirtualFile>,
 }
 
 impl Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,17 @@
 use crate::common::*;
+use std::collections::BTreeMap;
+
+#[derive(PartialEq, Debug, Deserialize, Clone)]
+enum VirtualFile {
+  Script { source: String },
+}
 
 #[derive(PartialEq, Debug, Default, Deserialize)]
 #[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
 pub(crate) struct Config {
   paid: Option<bool>,
   pub(crate) base_price: Option<Millisatoshi>,
+  files: BTreeMap<String, VirtualFile>,
 }
 
 impl Config {
@@ -44,6 +51,7 @@ impl Config {
     *self = Self {
       paid: self.paid.or(parent.paid),
       base_price: self.base_price.or(parent.base_price),
+      files: self.files.clone(),
     };
   }
 }
@@ -59,7 +67,8 @@ mod tests {
     assert_eq!(
       Config {
         paid: None,
-        base_price: None
+        base_price: None,
+        files: BTreeMap::new()
       },
       Config::default()
     );
@@ -81,7 +90,8 @@ mod tests {
       config,
       Config {
         paid: Some(true),
-        base_price: None
+        base_price: None,
+        files: BTreeMap::new()
       }
     );
   }
@@ -169,7 +179,8 @@ mod tests {
       config,
       Config {
         paid: Some(true),
-        base_price: Some(Millisatoshi::new(42_000))
+        base_price: Some(Millisatoshi::new(42_000)),
+        files: BTreeMap::new()
       }
     );
   }
@@ -189,7 +200,8 @@ mod tests {
       config,
       Config {
         paid: Some(false),
-        base_price: Some(Millisatoshi::new(42_000))
+        base_price: Some(Millisatoshi::new(42_000)),
+        files: BTreeMap::new()
       }
     );
   }
@@ -213,7 +225,8 @@ mod tests {
       config,
       Config {
         paid: Some(true),
-        base_price: Some(Millisatoshi::new(23_000))
+        base_price: Some(Millisatoshi::new(23_000)),
+        files: BTreeMap::new()
       }
     );
   }
@@ -237,7 +250,8 @@ mod tests {
       config,
       Config {
         paid: Some(true),
-        base_price: Some(Millisatoshi::new(42_000))
+        base_price: Some(Millisatoshi::new(42_000)),
+        files: BTreeMap::new()
       }
     );
   }
@@ -262,7 +276,8 @@ mod tests {
       config,
       Config {
         paid: Some(true),
-        base_price: Some(Millisatoshi::new(42_000))
+        base_price: Some(Millisatoshi::new(42_000)),
+        files: BTreeMap::new()
       }
     );
   }
@@ -283,7 +298,8 @@ mod tests {
       config,
       Config {
         paid: None,
-        base_price: None
+        base_price: None,
+        files: BTreeMap::new()
       }
     );
     let config = Config::for_dir(
@@ -295,7 +311,8 @@ mod tests {
       config,
       Config {
         paid: None,
-        base_price: None
+        base_price: None,
+        files: BTreeMap::new()
       }
     );
   }

--- a/src/files.rs
+++ b/src/files.rs
@@ -79,10 +79,24 @@ impl Files {
   ) -> Result<Response<Body>> {
     let file_path = self.file_path(&tail.join(""))?;
 
-    let config = self.config_for_dir(file_path.as_ref().parent().expect("fixme"));
-    dbg!(config);
-    if let Some(response) = crate::virtual_file::serve() {
-      return Ok(response);
+    if tail.len() > 0 {
+      let config = self
+        .config_for_dir(file_path.as_ref().parent().expect("fixme"))
+        .expect("fixme");
+      dbg!(&config);
+      if let Some(response) = crate::virtual_file::serve(
+        config,
+        file_path
+          .as_ref()
+          .file_name()
+          .expect("fixme")
+          .to_str()
+          .expect("fixme"),
+      )
+      .await
+      {
+        return Ok(response);
+      }
     }
 
     for result in self.base_directory.iter_prefixes(tail) {

--- a/src/files.rs
+++ b/src/files.rs
@@ -79,6 +79,12 @@ impl Files {
   ) -> Result<Response<Body>> {
     let file_path = self.file_path(&tail.join(""))?;
 
+    let config = self.config_for_dir(file_path.as_ref().parent().expect("fixme"));
+    dbg!(config);
+    if let Some(response) = crate::virtual_file::serve() {
+      return Ok(response);
+    }
+
     for result in self.base_directory.iter_prefixes(tail) {
       let prefix = result?;
       self.check_path(&prefix)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod static_assets;
 mod stderr;
 #[cfg(test)]
 mod tests;
+mod virtual_file;
 
 #[tokio::main]
 async fn main() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1072,19 +1072,20 @@ fn bugfix_symlink_with_relative_base_directory() {
 
 #[test]
 fn serve_script_output() {
-  let stderr = test(|context| async move {
+  test(|context| async move {
     let config = "
       files:
         foo:
           type: script
-          source: echo precious output
+          source: |
+            #!/usr/bin/env bash
+            echo precious output
     "
     .unindent();
     context.write(".agora.yaml", &config);
     let output = text(&context.files_url().join("foo").unwrap()).await;
-    // assert_eq!(output, "precious output");
+    assert_eq!(output, "precious output\n");
   });
-  panic!(stderr);
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1086,3 +1086,7 @@ fn serve_script_output() {
   });
   panic!(stderr);
 }
+
+#[test]
+#[ignore]
+fn what_if_virtual_file_names_contain_slashes() {}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1077,9 +1077,7 @@ fn serve_script_output() {
       files:
         foo:
           type: script
-          source: |
-            #!/usr/bin/env bash
-            echo precious output
+          source: echo precious output
     "
     .unindent();
     context.write(".agora.yaml", &config);
@@ -1087,6 +1085,28 @@ fn serve_script_output() {
     assert_eq!(output, "precious output\n");
   });
 }
+
+#[test]
+fn script_execution_honors_hashbangs() {
+  test(|context| async move {
+    let config = "
+      files:
+        foo:
+          type: script
+          source: |
+            #!/usr/bin/env python3
+            print('precious python output')
+    "
+    .unindent();
+    context.write(".agora.yaml", &config);
+    let output = text(&context.files_url().join("foo").unwrap()).await;
+    assert_eq!(output, "precious python output\n");
+  });
+}
+
+#[test]
+#[ignore]
+fn logs_script_execution_errors() {}
 
 #[test]
 #[ignore]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -12,6 +12,7 @@ use reqwest::{redirect::Policy, Client, Url};
 use scraper::{ElementRef, Html, Selector};
 use std::{net::TcpListener, path::MAIN_SEPARATOR};
 use tokio::net::TcpStream;
+use unindent::Unindent;
 
 #[cfg(feature = "slow-tests")]
 mod browser_tests;
@@ -1065,4 +1066,23 @@ fn bugfix_symlink_with_relative_base_directory() {
     let link = text(&context.files_url().join("link").unwrap()).await;
     assert_eq!(link, "precious content");
   });
+}
+
+// fixme: context.write should take AsRef<str>
+
+#[test]
+fn serve_script_output() {
+  let stderr = test(|context| async move {
+    let config = "
+      files:
+        foo:
+          type: script
+          source: echo precious output
+    "
+    .unindent();
+    context.write(".agora.yaml", &config);
+    let output = text(&context.files_url().join("foo").unwrap()).await;
+    // assert_eq!(output, "precious output");
+  });
+  panic!(stderr);
 }

--- a/src/virtual_file.rs
+++ b/src/virtual_file.rs
@@ -7,6 +7,11 @@ pub(crate) async fn serve(config: Config, file_name: &str) -> Option<Response<Bo
     None => None,
     Some(virtual_file) => {
       let VirtualFile::script { source } = virtual_file;
+      let source = if dbg!(source).starts_with("#!") {
+        source.to_string()
+      } else {
+        format!("#!/usr/bin/sh\n{}", source)
+      };
       let tempdir = TempDir::new().expect("fixme");
       let script_file = tempdir.path().join("script");
       tokio::fs::write(&script_file, source).await.expect("fixme");

--- a/src/virtual_file.rs
+++ b/src/virtual_file.rs
@@ -1,0 +1,5 @@
+use crate::common::*;
+
+pub(crate) fn serve() -> Option<Response<Body>> {
+  todo!()
+}

--- a/src/virtual_file.rs
+++ b/src/virtual_file.rs
@@ -1,5 +1,26 @@
 use crate::common::*;
+use cradle::prelude::*;
+use tempfile::TempDir;
 
-pub(crate) fn serve() -> Option<Response<Body>> {
-  todo!()
+pub(crate) async fn serve(config: Config, file_name: &str) -> Option<Response<Body>> {
+  match config.files.get(file_name) {
+    None => None,
+    Some(virtual_file) => {
+      let VirtualFile::script { source } = virtual_file;
+      let tempdir = TempDir::new().expect("fixme");
+      let script_file = tempdir.path().join("script");
+      tokio::fs::write(&script_file, source).await.expect("fixme");
+      run!(%"chmod +x", &script_file);
+      run!(%"cat", &script_file);
+      let output = tokio::process::Command::new(script_file)
+        .output()
+        .await
+        .expect("fixme");
+      Some(
+        Response::builder()
+          .body(output.stdout.into())
+          .expect("builder arguments are valid"),
+      )
+    }
+  }
 }


### PR DESCRIPTION
@casey: I was wrong about how processes get executed on linux: The kernel is capable of running scripts and binaries (e.g. ELF binaries), but in the case of scripts, they *have* to start with `#!`. So the kernel will *not* fall back on any shell, if the hashbang is missing. You can run scripts that don't start with `#!` from e.g. `bash`, and that will work by falling back on some shell, but that behavior is implemented in the shells you're using for that. (And apparently the exact behavior (e.g. which shell to use) depends on the parent shell being used.)

So this PR right now implements the following logic: When the given script starts with `#!` it is executed unmodified. If it doesn't a hashbang line is added (`#!/usr/bin/sh`). Judging from the tests that seems to be the behavior we want, but it's a bit magical.

The PR still needs to be cleaned up a lot, but I wanted to get your feedback early.