### PR TITLE
Create a virtual file system abstraction

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,8 @@ jobs:
         toolchain: 1.48.0
 
     - uses: Swatinem/rust-cache@v1
+      with:
+        key: 0
 
     - name: Check Lockfile
       run: cargo update --locked --package agora

--- a/src/files.rs
+++ b/src/files.rs
@@ -73,7 +73,7 @@ impl Files {
   fn render_index(&self, dir: &InputPath) -> Result<Option<Markup>> {
     use pulldown_cmark::{html, Options, Parser};
 
-    let markdown = match self.vfs.directory_markdown_file(dir)? {
+    let markdown = match self.vfs.index_file_markdown(dir)? {
       None => return Ok(None),
       Some(markdown) => markdown,
     };
@@ -142,7 +142,7 @@ impl Files {
     tail: &[&str],
     path: &InputPath,
   ) -> Result<Response<Body>> {
-    if !self.vfs.paid(path) {
+    if !self.vfs.paid(path)? {
       return Self::serve_file(path).await;
     }
 
@@ -154,7 +154,7 @@ impl Files {
     })?;
 
     let file_path = tail.join("");
-    let base_price = self.vfs.base_price(path).ok_or_else(|| {
+    let base_price = self.vfs.base_price(path)?.ok_or_else(|| {
       error::ConfigMissingBasePrice {
         path: path.display_path(),
       }

--- a/src/files.rs
+++ b/src/files.rs
@@ -100,15 +100,12 @@ impl Files {
     .remove(b'_')
     .remove(b'~');
 
-  fn render_index(dir: &InputPath) -> Result<Option<Markup>> {
+  fn render_index(&self, dir: &InputPath) -> Result<Option<Markup>> {
     use pulldown_cmark::{html, Options, Parser};
 
-    let file = dir.join_relative(".index.md".as_ref())?;
-
-    let markdown = match fs::read_to_string(&file) {
-      Ok(markdown) => markdown,
-      Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
-      Err(source) => return Err(Error::filesystem_io(&file).into_error(source)),
+    let markdown = match self.vfs.directory_markdown_file(dir)? {
+      None => return Ok(None),
+      Some(markdown) => markdown,
     };
 
     let options = Options::ENABLE_FOOTNOTES
@@ -153,7 +150,7 @@ impl Files {
           }
         }
       }
-      @if let Some(index) = Self::render_index(dir)? {
+      @if let Some(index) = self.render_index(dir)? {
         div {
           (index)
         }

--- a/src/files.rs
+++ b/src/files.rs
@@ -83,11 +83,7 @@ impl Files {
       self.check_path(&prefix)?;
     }
 
-    let file_type = file_path
-      .as_ref()
-      .metadata()
-      .with_context(|| Error::filesystem_io(&file_path))?
-      .file_type();
+    let file_type = self.vfs.file_type(tail)?;
 
     if !file_type.is_dir() {
       if let Some(stripped) = request.uri().path().strip_suffix('/') {

--- a/src/files.rs
+++ b/src/files.rs
@@ -111,8 +111,7 @@ impl Files {
                 (bytes.display_size())
               }
             }
-            // if vfs.paid(file)
-            @if entry.file_type.is_file() && !self.vfs.paid(&dir.join_relative(entry.file_name.as_ref()).unwrap()) {
+            @if entry.file_type.is_file() && !entry.paid {
               a download href=(encoded) {
                 (Files::icon("download"))
               }

--- a/src/files.rs
+++ b/src/files.rs
@@ -78,11 +78,6 @@ impl Files {
   ) -> Result<Response<Body>> {
     let file_path = self.file_path(&tail.join(""))?;
 
-    for result in self.base_directory.iter_prefixes(tail) {
-      let prefix = result?;
-      self.check_path(&prefix)?;
-    }
-
     let file_type = self.vfs.file_type(tail)?;
 
     if !file_type.is_dir() {

--- a/src/files.rs
+++ b/src/files.rs
@@ -107,9 +107,9 @@ impl Files {
               (file_name)
             }
 
-            @if let Some(bytes) = entry.file_size {
+            @if let Some(file_size) = entry.file_size {
               span class="filesize" {
-                (bytes.display_size())
+                (file_size.display_size())
               }
             }
             @if entry.file_type.is_file() && !entry.paid {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod static_assets;
 mod stderr;
 #[cfg(test)]
 mod tests;
+mod vfs;
 
 #[tokio::main]
 async fn main() {

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -130,6 +130,7 @@ impl Vfs {
         file_name: entry.file_name(),
         file_type,
         file_size,
+        paid: self.paid(&path.join_relative(entry.file_name().as_ref()).unwrap()),
       });
     }
     entries.sort_by(|a, b| a.file_name.cmp(&b.file_name));
@@ -141,4 +142,5 @@ pub(crate) struct DirectoryEntry {
   pub(crate) file_name: OsString,
   pub(crate) file_type: FileType,
   pub(crate) file_size: Option<u64>,
+  pub(crate) paid: bool,
 }

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -29,6 +29,10 @@ impl Vfs {
     config.base_price
   }
 
+  pub(crate) fn file_path(&self, path: &str) -> Result<InputPath> {
+    self.base_directory.join_file_path(path)
+  }
+
   pub(crate) fn file_type(&self, tail: &[&str]) -> Result<FileType> {
     for result in self.base_directory.iter_prefixes(tail) {
       let prefix = result?;

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -10,6 +10,18 @@ impl Vfs {
     Self { base_directory }
   }
 
+  fn config(&self, path: &InputPath) -> Result<Config> {
+    Config::for_dir(
+      self.base_directory.as_ref(),
+      path.as_ref().parent().ok_or_else(|| {
+        Error::internal(format!(
+          "Path {} has no parent",
+          path.display_path().display()
+        ))
+      })?,
+    )
+  }
+
   /// If an `.index.md` file exists in this directory, return its contents as a string.
   pub(crate) fn index_file_markdown(&self, dir_path: &InputPath) -> Result<Option<String>> {
     self.check_path(&dir_path)?;
@@ -22,31 +34,13 @@ impl Vfs {
   }
 
   pub(crate) fn paid(&self, path: &InputPath) -> Result<bool> {
-    self.check_path(&path)?;
-    let config = Config::for_dir(
-      self.base_directory.as_ref(),
-      path.as_ref().parent().ok_or_else(|| {
-        Error::internal(format!(
-          "Path {} has no parent",
-          path.display_path().display()
-        ))
-      })?,
-    )?;
-    Ok(config.paid())
+    self.check_path(path)?;
+    Ok(self.config(path)?.paid())
   }
 
   pub(crate) fn base_price(&self, path: &InputPath) -> Result<Option<Millisatoshi>> {
     self.check_path(&path)?;
-    let config = Config::for_dir(
-      self.base_directory.as_ref(),
-      path.as_ref().parent().ok_or_else(|| {
-        Error::internal(format!(
-          "Path {} has no parent",
-          path.display_path().display()
-        ))
-      })?,
-    )?;
-    Ok(config.base_price)
+    Ok(self.config(path)?.base_price)
   }
 
   pub(crate) fn file_path(&self, path: &str) -> Result<InputPath> {

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -30,6 +30,12 @@ impl Vfs {
     }
 
     pub(crate) fn file_type(&self, tail: &[&str]) -> Result<FileType> {
+
+        for result in self.base_directory.iter_prefixes(tail) {
+            let prefix = result?;
+            self.check_path(&prefix)?;
+        }
+
         let file_path = self.base_directory.join_file_path(&tail.join(""))?;
         let file_type = file_path
             .as_ref()
@@ -38,4 +44,49 @@ impl Vfs {
             .file_type();
         Ok(file_type)
     }
+
+  fn check_path(&self, path: &InputPath) -> Result<()> {
+    if path
+      .as_ref()
+      .symlink_metadata()
+      .with_context(|| Error::filesystem_io(path))?
+      .file_type()
+      .is_symlink()
+    {
+      let link = fs::read_link(path.as_ref()).with_context(|| Error::filesystem_io(path))?;
+
+      let destination = path
+        .as_ref()
+        .parent()
+        .expect("Input paths are always absolute, and thus have parents or are `/`, and `/` cannot be a symlink.")
+        .join(link)
+        .lexiclean();
+
+      if !destination.starts_with(&self.base_directory) {
+        return Err(
+          error::SymlinkAccess {
+            path: path.display_path().to_owned(),
+          }
+          .build(),
+        );
+      }
+    }
+
+    if path
+      .as_ref()
+      .file_name()
+      .map(|file_name| file_name.to_string_lossy().starts_with('.'))
+      .unwrap_or(false)
+    {
+      return Err(
+        error::HiddenFileAccess {
+          path: path.as_ref().to_owned(),
+        }
+        .build(),
+      );
+    }
+
+    Ok(())
+
+  }
 }

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -19,31 +19,30 @@ impl Vfs {
     config.paid()
   }
 
-    pub(crate) fn base_price(&self, path: &InputPath) -> Option<Millisatoshi> {
+  pub(crate) fn base_price(&self, path: &InputPath) -> Option<Millisatoshi> {
     let config = Config::for_dir(
       self.base_directory.as_ref(),
       path.as_ref().parent().unwrap(),
     )
     .unwrap();
 
-        config.base_price
+    config.base_price
+  }
+
+  pub(crate) fn file_type(&self, tail: &[&str]) -> Result<FileType> {
+    for result in self.base_directory.iter_prefixes(tail) {
+      let prefix = result?;
+      self.check_path(&prefix)?;
     }
 
-    pub(crate) fn file_type(&self, tail: &[&str]) -> Result<FileType> {
-
-        for result in self.base_directory.iter_prefixes(tail) {
-            let prefix = result?;
-            self.check_path(&prefix)?;
-        }
-
-        let file_path = self.base_directory.join_file_path(&tail.join(""))?;
-        let file_type = file_path
-            .as_ref()
-            .metadata()
-            .with_context(|| Error::filesystem_io(&file_path))?
-            .file_type();
-        Ok(file_type)
-    }
+    let file_path = self.base_directory.join_file_path(&tail.join(""))?;
+    let file_type = file_path
+      .as_ref()
+      .metadata()
+      .with_context(|| Error::filesystem_io(&file_path))?
+      .file_type();
+    Ok(file_type)
+  }
 
   pub(crate) fn check_path(&self, path: &InputPath) -> Result<()> {
     if path
@@ -87,6 +86,5 @@ impl Vfs {
     }
 
     Ok(())
-
   }
 }

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -15,8 +15,8 @@ impl Vfs {
     let file = dir_path.join_relative(".index.md".as_ref())?;
     match fs::read_to_string(&file) {
       Ok(markdown) => Ok(Some(markdown)),
-      Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
-      Err(source) => return Err(Error::filesystem_io(&file).into_error(source)),
+      Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+      Err(source) => Err(Error::filesystem_io(&file).into_error(source)),
     }
   }
 
@@ -58,7 +58,7 @@ impl Vfs {
     Ok(file_type)
   }
 
-  pub(crate) fn check_path(&self, path: &InputPath) -> Result<()> {
+  fn check_path(&self, path: &InputPath) -> Result<()> {
     if path
       .as_ref()
       .symlink_metadata()

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -10,6 +10,16 @@ impl Vfs {
     Self { base_directory }
   }
 
+  /// If an `.index.md` file exists in this directory, return its contents as a string.
+  pub(crate) fn directory_markdown_file(&self, dir_path: &InputPath) -> Result<Option<String>> {
+    let file = dir_path.join_relative(".index.md".as_ref())?;
+    match fs::read_to_string(&file) {
+      Ok(markdown) => Ok(Some(markdown)),
+      Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+      Err(source) => return Err(Error::filesystem_io(&file).into_error(source)),
+    }
+  }
+
   pub(crate) fn paid(&self, path: &InputPath) -> bool {
     let config = Config::for_dir(
       self.base_directory.as_ref(),

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -28,4 +28,14 @@ impl Vfs {
 
         config.base_price
     }
+
+    pub(crate) fn file_type(&self, tail: &[&str]) -> Result<FileType> {
+        let file_path = self.base_directory.join_file_path(&tail.join(""))?;
+        let file_type = file_path
+            .as_ref()
+            .metadata()
+            .with_context(|| Error::filesystem_io(&file_path))?
+            .file_type();
+        Ok(file_type)
+    }
 }

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -1,0 +1,21 @@
+use crate::common::*;
+
+#[derive(Debug, Clone)]
+pub(crate) struct Vfs {
+  base_directory: InputPath,
+}
+
+impl Vfs {
+  pub(crate) fn new(base_directory: InputPath) -> Self {
+    Self { base_directory }
+  }
+
+  pub(crate) fn paid(&self, path: &InputPath) -> bool {
+    let config = Config::for_dir(
+      self.base_directory.as_ref(),
+      path.as_ref().parent().unwrap(),
+    )
+    .unwrap();
+    config.paid()
+  }
+}

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -45,7 +45,7 @@ impl Vfs {
         Ok(file_type)
     }
 
-  fn check_path(&self, path: &InputPath) -> Result<()> {
+  pub(crate) fn check_path(&self, path: &InputPath) -> Result<()> {
     if path
       .as_ref()
       .symlink_metadata()

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -18,4 +18,14 @@ impl Vfs {
     .unwrap();
     config.paid()
   }
+
+    pub(crate) fn base_price(&self, path: &InputPath) -> Option<Millisatoshi> {
+    let config = Config::for_dir(
+      self.base_directory.as_ref(),
+      path.as_ref().parent().unwrap(),
+    )
+    .unwrap();
+
+        config.base_price
+    }
 }

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -12,6 +12,7 @@ impl Vfs {
 
   /// If an `.index.md` file exists in this directory, return its contents as a string.
   pub(crate) fn index_file_markdown(&self, dir_path: &InputPath) -> Result<Option<String>> {
+    self.check_path(&dir_path)?;
     let file = dir_path.join_relative(".index.md".as_ref())?;
     match fs::read_to_string(&file) {
       Ok(markdown) => Ok(Some(markdown)),
@@ -21,6 +22,7 @@ impl Vfs {
   }
 
   pub(crate) fn paid(&self, path: &InputPath) -> Result<bool> {
+    self.check_path(&path)?;
     let config = Config::for_dir(
       self.base_directory.as_ref(),
       path.as_ref().parent().ok_or_else(|| {
@@ -34,6 +36,7 @@ impl Vfs {
   }
 
   pub(crate) fn base_price(&self, path: &InputPath) -> Result<Option<Millisatoshi>> {
+    self.check_path(&path)?;
     let config = Config::for_dir(
       self.base_directory.as_ref(),
       path.as_ref().parent().ok_or_else(|| {

--- a/tests/backtrace.rs
+++ b/tests/backtrace.rs
@@ -10,5 +10,5 @@ fn errors_contain_backtraces() {
     .status();
   assert_eq!(status, StatusCode::NOT_FOUND);
   let stderr = agora.kill();
-  assert!(stderr.contains("agora::files::Files::check_path"));
+  assert!(stderr.contains("agora::vfs::Vfs::check_path"));
 }


### PR DESCRIPTION
This commit is the first stab at creating a virtual filesystem abstraction. Eventually, `vfs.rs` is the only place in the codebase that should use APIs that directly access the file system. Other components of the system should go through the VFS to access file data and list the contents of directories, letting the VFS take care of reading the configuration file hierarchy, ignoring hidden files, and similar bookkeeping. 