### PR TITLE
Cloalesce import statements

### DIFF
--- a/agora-lnd-client/src/https_service.rs
+++ b/agora-lnd-client/src/https_service.rs
@@ -1,10 +1,12 @@
-use http::uri::{Authority, Scheme, Uri};
-use hyper::{client::connect::HttpConnector, Body, Request, Response};
-use hyper_openssl::HttpsConnector;
-use openssl::ssl::{SslConnector, SslMethod};
-use openssl::x509::X509;
-use std::task::{Context, Poll};
-use tonic::body::BoxBody;
+use {
+  http::uri::{Authority, Scheme, Uri},
+  hyper::{client::connect::HttpConnector, Body, Request, Response},
+  hyper_openssl::HttpsConnector,
+  openssl::ssl::{SslConnector, SslMethod},
+  openssl::x509::X509,
+  std::task::{Context, Poll},
+  tonic::body::BoxBody,
+};
 
 #[derive(Clone, Debug)]
 pub(crate) struct HttpsService {

--- a/agora-lnd-client/src/lib.rs
+++ b/agora-lnd-client/src/lib.rs
@@ -1,19 +1,20 @@
-use crate::https_service::HttpsService;
-use http::uri::Authority;
-#[cfg(test)]
-use lnd_test_context::LndTestContext;
-use lnrpc::{
-  lightning_client::LightningClient, AddInvoiceResponse, Invoice, ListInvoiceRequest, PaymentHash,
+use {
+  crate::https_service::HttpsService,
+  http::uri::Authority,
+  lnrpc::{
+    lightning_client::LightningClient, AddInvoiceResponse, Invoice, ListInvoiceRequest, PaymentHash,
+  },
+  openssl::x509::X509,
+  std::convert::TryInto,
+  tonic::{
+    metadata::AsciiMetadataValue,
+    service::interceptor::{InterceptedService, Interceptor},
+    Code, Request, Status,
+  },
 };
-use openssl::x509::X509;
-use std::convert::TryInto;
+
 #[cfg(test)]
-use std::sync::Arc;
-use tonic::{
-  metadata::AsciiMetadataValue,
-  service::interceptor::{InterceptedService, Interceptor},
-  Code, Request, Status,
-};
+use {lnd_test_context::LndTestContext, std::sync::Arc};
 
 pub use millisatoshi::Millisatoshi;
 

--- a/agora-lnd-client/src/millisatoshi.rs
+++ b/agora-lnd-client/src/millisatoshi.rs
@@ -1,9 +1,11 @@
-use regex::Regex;
-use serde::{
-  de::{self, Visitor},
-  Deserialize, Deserializer,
+use {
+  regex::Regex,
+  serde::{
+    de::{self, Visitor},
+    Deserialize, Deserializer,
+  },
+  std::fmt::{self, Display, Formatter},
 };
-use std::fmt::{self, Display, Formatter};
 
 #[derive(PartialEq, Debug, Clone, Copy)]
 pub struct Millisatoshi(u64);

--- a/agora-test-context/src/lib.rs
+++ b/agora-test-context/src/lib.rs
@@ -1,4 +1,4 @@
-use ::{
+use {
   executable_path::executable_path,
   reqwest::Url,
   std::{

--- a/bin/prerelease/src/main.rs
+++ b/bin/prerelease/src/main.rs
@@ -1,5 +1,4 @@
-use regex::Regex;
-use structopt::StructOpt;
+use {regex::Regex, structopt::StructOpt};
 
 #[derive(StructOpt)]
 struct Arguments {

--- a/bin/prerelease/tests/integration.rs
+++ b/bin/prerelease/tests/integration.rs
@@ -1,5 +1,7 @@
-use executable_path::executable_path;
-use std::{process::Command, str};
+use {
+  executable_path::executable_path,
+  std::{process::Command, str},
+};
 
 fn stdout(reference: &str) -> String {
   let output = Command::new(executable_path("prerelease"))

--- a/bin/publish/src/main.rs
+++ b/bin/publish/src/main.rs
@@ -1,8 +1,7 @@
-use cargo_metadata::MetadataCommand;
-use cradle::prelude::*;
-use std::env;
-use structopt::StructOpt;
-use tempfile::tempdir;
+use {
+  cargo_metadata::MetadataCommand, cradle::prelude::*, std::env, structopt::StructOpt,
+  tempfile::tempdir,
+};
 
 #[derive(StructOpt)]
 struct Arguments {

--- a/lnd-test-context/src/executables.rs
+++ b/lnd-test-context/src/executables.rs
@@ -1,13 +1,15 @@
-use cradle::prelude::*;
-use hex_literal::hex;
-use lazy_static::lazy_static;
-use pretty_assertions::assert_eq;
-use sha2::{Digest, Sha256};
-use std::{
-  env::{self, consts::EXE_SUFFIX},
-  fs,
-  io::{self, Write},
-  path::{Path, PathBuf},
+use {
+  cradle::prelude::*,
+  hex_literal::hex,
+  lazy_static::lazy_static,
+  pretty_assertions::assert_eq,
+  sha2::{Digest, Sha256},
+  std::{
+    env::{self, consts::EXE_SUFFIX},
+    fs,
+    io::{self, Write},
+    path::{Path, PathBuf},
+  },
 };
 
 pub fn target_dir() -> &'static Path {

--- a/lnd-test-context/src/lib.rs
+++ b/lnd-test-context/src/lib.rs
@@ -1,17 +1,19 @@
-use crate::owned_child::{CommandExt, OwnedChild};
-use cradle::prelude::*;
-use lazy_static::lazy_static;
-use std::{
-  collections::BTreeSet,
-  fs,
-  net::TcpListener,
-  path::{Path, PathBuf},
-  process::Command,
-  sync::Arc,
-  time::Duration,
+use {
+  crate::owned_child::{CommandExt, OwnedChild},
+  cradle::prelude::*,
+  lazy_static::lazy_static,
+  std::{
+    collections::BTreeSet,
+    fs,
+    net::TcpListener,
+    path::{Path, PathBuf},
+    process::Command,
+    sync::Arc,
+    time::Duration,
+  },
+  tempfile::TempDir,
+  tokio::sync::Mutex,
 };
-use tempfile::TempDir;
-use tokio::sync::Mutex;
 
 mod executables;
 mod owned_child;

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -1,5 +1,7 @@
-use crate::common::*;
-use structopt::clap::{AppSettings, ArgGroup};
+use {
+  crate::common::*,
+  structopt::clap::{AppSettings, ArgGroup},
+};
 
 #[derive(Debug, StructOpt)]
 #[structopt(

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,12 @@
-use crate::common::*;
-use color_backtrace::BacktracePrinter;
-use snafu::{ErrorCompat, Snafu};
-use std::{path::MAIN_SEPARATOR, str::Utf8Error};
-use structopt::clap;
-use termcolor::WriteColor;
-use tokio::task::JoinError;
+use {
+  crate::common::*,
+  color_backtrace::BacktracePrinter,
+  snafu::{ErrorCompat, Snafu},
+  std::{path::MAIN_SEPARATOR, str::Utf8Error},
+  structopt::clap,
+  termcolor::WriteColor,
+  tokio::task::JoinError,
+};
 
 pub(crate) type Result<T, E = Error> = std::result::Result<T, E>;
 

--- a/src/error_page.rs
+++ b/src/error_page.rs
@@ -1,5 +1,4 @@
-use crate::common::*;
-use maud::html;
+use {crate::common::*, maud::html};
 
 pub(crate) fn map_error(
   mut stderr: Stderr,

--- a/src/file_stream.rs
+++ b/src/file_stream.rs
@@ -1,9 +1,11 @@
-use crate::common::*;
-use hyper::body::Bytes;
-use pin_project::pin_project;
-use tokio::{
-  fs::File,
-  io::{AsyncRead, ReadBuf},
+use {
+  crate::common::*,
+  hyper::body::Bytes,
+  pin_project::pin_project,
+  tokio::{
+    fs::File,
+    io::{AsyncRead, ReadBuf},
+  },
 };
 
 #[pin_project]

--- a/src/files.rs
+++ b/src/files.rs
@@ -1,7 +1,9 @@
-use crate::{common::*, file_stream::FileStream};
-use agora_lnd_client::lnrpc::invoice::InvoiceState;
-use maud::html;
-use percent_encoding::{AsciiSet, NON_ALPHANUMERIC};
+use {
+  crate::{common::*, file_stream::FileStream},
+  agora_lnd_client::lnrpc::invoice::InvoiceState,
+  maud::html,
+  percent_encoding::{AsciiSet, NON_ALPHANUMERIC},
+};
 
 #[derive(Clone, Debug)]
 pub(crate) struct Files {

--- a/src/html.rs
+++ b/src/html.rs
@@ -1,5 +1,7 @@
-use crate::common::*;
-use maud::{html, DOCTYPE};
+use {
+  crate::common::*,
+  maud::{html, DOCTYPE},
+};
 
 pub(crate) fn wrap_body(title_slug: &str, body: Markup) -> Response<Body> {
   let html = html! {

--- a/src/https_redirect_service.rs
+++ b/src/https_redirect_service.rs
@@ -1,5 +1,4 @@
-use crate::common::*;
-use tower::make::Shared;
+use {crate::common::*, tower::make::Shared};
 
 #[derive(Clone)]
 pub(crate) struct HttpsRedirectService {

--- a/src/https_request_handler.rs
+++ b/src/https_request_handler.rs
@@ -1,15 +1,16 @@
-use crate::common::*;
-
-use hyper::server::conn::Http;
-use rustls_acme::{
-  acme::{ACME_TLS_ALPN_NAME, LETS_ENCRYPT_PRODUCTION_DIRECTORY, LETS_ENCRYPT_STAGING_DIRECTORY},
-  ResolvesServerCertUsingAcme,
+use {
+  crate::common::*,
+  hyper::server::conn::Http,
+  rustls_acme::{
+    acme::{ACME_TLS_ALPN_NAME, LETS_ENCRYPT_PRODUCTION_DIRECTORY, LETS_ENCRYPT_STAGING_DIRECTORY},
+    ResolvesServerCertUsingAcme,
+  },
+  tokio_rustls::{
+    rustls::{NoClientAuth, ServerConfig, Session},
+    server::TlsStream,
+  },
+  tokio_stream::wrappers::TcpListenerStream,
 };
-use tokio_rustls::{
-  rustls::{NoClientAuth, ServerConfig, Session},
-  server::TlsStream,
-};
-use tokio_stream::wrappers::TcpListenerStream;
 
 pub(crate) struct HttpsRequestHandler {
   request_handler: RequestHandler,

--- a/src/input_path.rs
+++ b/src/input_path.rs
@@ -1,6 +1,4 @@
-use crate::common::*;
-use mime_guess::MimeGuess;
-use std::path::Component;
+use {crate::common::*, mime_guess::MimeGuess, std::path::Component};
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct InputPath {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,6 +1,4 @@
-use crate::common::*;
-use openssl::x509::X509;
-use tower::make::Shared;
+use {crate::common::*, openssl::x509::X509, tower::make::Shared};
 
 pub(crate) struct Server {
   http_request_handler: Option<hyper::Server<AddrIncoming, Shared<RequestHandler>>>,

--- a/src/static_assets.rs
+++ b/src/static_assets.rs
@@ -1,5 +1,4 @@
-use crate::common::*;
-use rust_embed::RustEmbed;
+use {crate::common::*, rust_embed::RustEmbed};
 
 #[derive(RustEmbed)]
 #[folder = "static/"]

--- a/src/stderr.rs
+++ b/src/stderr.rs
@@ -1,5 +1,7 @@
-use crate::common::*;
-use termcolor::{ColorSpec, WriteColor};
+use {
+  crate::common::*,
+  termcolor::{ColorSpec, WriteColor},
+};
 
 #[cfg(test)]
 use std::sync::Mutex;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,9 +1,11 @@
-use crate::common::*;
-use crate::server::TestContext;
+use {
+  crate::{common::*, server::TestContext},
+  reqwest::{Certificate, Client, ClientBuilder},
+  std::panic,
+};
+
 #[cfg(feature = "slow-tests")]
 use lnd_test_context::LndTestContext;
-use reqwest::{Certificate, Client, ClientBuilder};
-use std::panic;
 
 macro_rules! assert_matches {
   ($expression:expr, $( $pattern:pat )|+ $( if $guard:expr )?) => {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,14 +1,16 @@
-use crate::{
-  common::*,
-  test_utils::{
-    assert_contains, https_client, set_up_test_certificate, test_with_arguments,
-    test_with_environment,
+use {
+  crate::{
+    common::*,
+    test_utils::{
+      assert_contains, https_client, set_up_test_certificate, test_with_arguments,
+      test_with_environment,
+    },
   },
+  guard::guard_unwrap,
+  pretty_assertions::assert_eq,
+  reqwest::Url,
+  std::net::TcpListener,
 };
-use guard::guard_unwrap;
-use pretty_assertions::assert_eq;
-use reqwest::Url;
-use std::net::TcpListener;
 
 #[cfg(feature = "slow-tests")]
 mod browser_tests;

--- a/src/tests/browser_tests.rs
+++ b/src/tests/browser_tests.rs
@@ -1,14 +1,18 @@
-use crate::{
-  common::*,
-  test_utils::{set_up_test_certificate, test_with_arguments, test_with_lnd},
+use {
+  crate::{
+    common::*,
+    test_utils::{set_up_test_certificate, test_with_arguments, test_with_lnd},
+  },
+  chromiumoxide::{
+    browser::BrowserConfig,
+    cdp::browser_protocol::browser::{
+      PermissionDescriptor, PermissionSetting, SetPermissionParams,
+    },
+    Page,
+  },
+  lnd_test_context::LndTestContext,
+  pretty_assertions::assert_eq,
 };
-use chromiumoxide::{
-  browser::BrowserConfig,
-  cdp::browser_protocol::browser::{PermissionDescriptor, PermissionSetting, SetPermissionParams},
-  Page,
-};
-use lnd_test_context::LndTestContext;
-use pretty_assertions::assert_eq;
 
 struct Browser {
   inner: chromiumoxide::Browser,

--- a/src/tests/slow_tests.rs
+++ b/src/tests/slow_tests.rs
@@ -1,14 +1,16 @@
-use super::*;
-use crate::{
-  server::TestContext,
-  test_utils::{assert_contains, test_with_arguments, test_with_lnd},
+use {
+  super::*,
+  crate::{
+    server::TestContext,
+    test_utils::{assert_contains, test_with_arguments, test_with_lnd},
+  },
+  guard::guard_unwrap,
+  lnd_test_context::LndTestContext,
+  pretty_assertions::assert_eq,
+  regex::Regex,
+  scraper::{ElementRef, Html, Selector},
+  std::path::MAIN_SEPARATOR,
 };
-use guard::guard_unwrap;
-use lnd_test_context::LndTestContext;
-use pretty_assertions::assert_eq;
-use regex::Regex;
-use scraper::{ElementRef, Html, Selector};
-use std::path::MAIN_SEPARATOR;
 
 async fn html(url: &Url) -> Html {
   Html::parse_document(&text(url).await)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,4 +1,4 @@
-use ::{
+use {
   agora_test_context::AgoraInstance,
   guard::guard_unwrap,
   hyper::{header, StatusCode},

--- a/tests/status.rs
+++ b/tests/status.rs
@@ -1,5 +1,4 @@
-use executable_path::executable_path;
-use std::process::Command;
+use {executable_path::executable_path, std::process::Command};
 
 #[test]
 fn help_returns_success() {


### PR DESCRIPTION
Coalesces groups of import statements into single statements. Nice because you don't need to type `use`. May be gratuitous 🥺