### PR TITLE
Update proc-macro2 to 1.0.33, allow to run tests with cranelift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,7 +405,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
 dependencies = [
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "quote 1.0.10",
  "syn 1.0.80",
 ]
@@ -422,7 +422,7 @@ version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
 dependencies = [
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "quote 1.0.10",
  "syn 1.0.80",
 ]
@@ -699,7 +699,7 @@ dependencies = [
  "either",
  "heck",
  "once_cell",
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "quote 1.0.10",
  "regex",
  "serde",
@@ -917,7 +917,7 @@ dependencies = [
  "itoa",
  "matches",
  "phf",
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "quote 1.0.10",
  "smallvec",
  "syn 1.0.80",
@@ -1043,7 +1043,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "quote 1.0.10",
  "rustc_version 0.3.3",
  "syn 1.0.80",
@@ -1166,7 +1166,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "quote 1.0.10",
  "syn 1.0.80",
  "synstructure",
@@ -1334,7 +1334,7 @@ checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
 dependencies = [
  "autocfg",
  "proc-macro-hack",
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "quote 1.0.10",
  "syn 1.0.80",
 ]
@@ -1557,7 +1557,7 @@ dependencies = [
  "log",
  "mac",
  "markup5ever",
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "quote 1.0.10",
  "syn 1.0.80",
 ]
@@ -1990,7 +1990,7 @@ checksum = "e6896f8e8cdcea80b99ac0f1f7a233708e640737a8517448f50500e401bb8d76"
 dependencies = [
  "maud_htmlescape",
  "proc-macro-error",
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "quote 1.0.10",
  "syn 1.0.80",
 ]
@@ -2441,7 +2441,7 @@ dependencies = [
  "phf_generator",
  "phf_shared",
  "proc-macro-hack",
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "quote 1.0.10",
  "syn 1.0.80",
 ]
@@ -2476,7 +2476,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
 dependencies = [
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "quote 1.0.10",
  "syn 1.0.80",
 ]
@@ -2609,7 +2609,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "quote 1.0.10",
  "syn 1.0.80",
  "version_check",
@@ -2621,7 +2621,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "quote 1.0.10",
  "version_check",
 ]
@@ -2649,9 +2649,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.30"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc3358ebc67bc8b7fa0c007f945b0b18226f78437d61bec735a9eb96b61ee70"
+checksum = "fb37d2df5df740e582f28f8560cf425f52bb267d872fe58358eadb554909f07a"
 dependencies = [
  "unicode-xid 0.2.2",
 ]
@@ -2692,7 +2692,7 @@ checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "quote 1.0.10",
  "syn 1.0.80",
 ]
@@ -2756,7 +2756,7 @@ version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
 ]
 
 [[package]]
@@ -3037,7 +3037,7 @@ version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e763e24ba2bf0c72bc6be883f967f794a019fafd1b86ba1daff9c91a7edd30"
 dependencies = [
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "quote 1.0.10",
  "rust-embed-utils",
  "syn 1.0.80",
@@ -3328,7 +3328,7 @@ version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "quote 1.0.10",
  "syn 1.0.80",
 ]
@@ -3499,7 +3499,7 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1508efa03c362e23817f96cde18abed596a25219a8b2c66e8db33c03543d315b"
 dependencies = [
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "quote 1.0.10",
  "syn 1.0.80",
 ]
@@ -3561,7 +3561,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "quote 1.0.10",
  "serde",
  "serde_derive",
@@ -3575,7 +3575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "quote 1.0.10",
  "serde",
  "serde_derive",
@@ -3612,7 +3612,7 @@ checksum = "f24c8e5e19d22a726626f1a5e16fe15b132dcf21d10177fa5a45ce7962996b97"
 dependencies = [
  "phf_generator",
  "phf_shared",
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "quote 1.0.10",
 ]
 
@@ -3641,7 +3641,7 @@ checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "quote 1.0.10",
  "syn 1.0.80",
 ]
@@ -3689,7 +3689,7 @@ version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
 dependencies = [
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "quote 1.0.10",
  "unicode-xid 0.2.2",
 ]
@@ -3700,7 +3700,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "quote 1.0.10",
  "syn 1.0.80",
  "unicode-xid 0.2.2",
@@ -3787,7 +3787,7 @@ version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "quote 1.0.10",
  "syn 1.0.80",
 ]
@@ -3846,7 +3846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "quote 1.0.10",
  "standback",
  "syn 1.0.80",
@@ -3915,7 +3915,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2dd85aeaba7b68df939bd357c6afb36c87951be9e80bf9c859f2fc3e9fca0fd"
 dependencies = [
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "quote 1.0.10",
  "syn 1.0.80",
 ]
@@ -4006,7 +4006,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12b52d07035516c2b74337d2ac7746075e7dcae7643816c1b12c5ff8a7484c08"
 dependencies = [
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "prost-build",
  "quote 1.0.10",
  "syn 1.0.80",
@@ -4064,7 +4064,7 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
 dependencies = [
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "quote 1.0.10",
  "syn 1.0.80",
 ]
@@ -4370,7 +4370,7 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "quote 1.0.10",
  "syn 1.0.80",
  "wasm-bindgen-shared",
@@ -4404,7 +4404,7 @@ version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
 dependencies = [
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.33",
  "quote 1.0.10",
  "syn 1.0.80",
  "wasm-bindgen-backend",


### PR DESCRIPTION
This PR allows to run the agora test-suite with cranelift. See https://github.com/bjorn3/rustc_codegen_cranelift/issues/1101.

One obvious advantage of cranelift is that compilation is faster, and one obvious downside is that executing the tests is slower. There may be other implications. So I'm not sure whether running the tests with cranelift is actually a good idea. In any case updating the `proc-macro2` version shouldn't hurt, and it allows us to experiment with cranelift.

See also https://github.com/bjorn3/rustc_codegen_cranelift#readme for a description on how to set up cranelift.