### PR TITLE
Use 402 status code and update tests.

### DIFF
--- a/src/files.rs
+++ b/src/files.rs
@@ -221,7 +221,7 @@ impl Files {
       _ => {
         let qr_code_url = format!("/invoice/{}.svg", hex::encode(invoice.r_hash));
         let filename = invoice.memo;
-        Ok(html::wrap_body(
+        let mut response = html::wrap_body(
           &format!("Invoice for {}", filename),
           html! {
             div class="invoice" {
@@ -277,7 +277,9 @@ impl Files {
               }
             }
           },
-        ))
+        );
+        *response.status_mut() = StatusCode::PAYMENT_REQUIRED;
+        Ok(response)
       }
     }
   }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -14,14 +14,28 @@ mod browser_tests;
 #[cfg(feature = "slow-tests")]
 mod slow_tests;
 
-async fn get(url: &reqwest::Url) -> reqwest::Response {
+async fn get_with_status(url: &reqwest::Url, status_code: reqwest::StatusCode) -> reqwest::Response {
   let response = reqwest::get(url.clone()).await.unwrap();
-  assert_eq!(response.status(), reqwest::StatusCode::OK);
+  assert_eq!(response.status(), status_code);
   response
+}
+
+async fn get(url: &reqwest::Url) -> reqwest::Response {
+  get_with_status(url, reqwest::StatusCode::OK).await
+}
+
+#[cfg(feature = "slow-tests")]
+async fn get_payment_required(url: &reqwest::Url) -> reqwest::Response {
+  get_with_status(url, reqwest::StatusCode::PAYMENT_REQUIRED).await
 }
 
 async fn text(url: &reqwest::Url) -> String {
   get(url).await.text().await.unwrap()
+}
+
+#[cfg(feature = "slow-tests")]
+async fn text_payment_required(url: &reqwest::Url) -> String {
+  get_payment_required(url).await.text().await.unwrap()
 }
 
 #[test]


### PR DESCRIPTION
Use status code 402 when a file requires payment.

From [Mozilla](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/402):

> The HTTP 402 Payment Required is a nonstandard response status code that is reserved for future use. This status code was created to enable digital cash or (micro) payment systems and would indicate that the requested content is not available until the client makes a payment.
> 
> Sometimes, this status code indicates that the request cannot be processed until the client makes a payment. However, no standard use convention exists and different entities use it in different contexts.
