### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Public Agora instances:
 
 - [tmcalh6tjskfmnjsipi4tqlzcr4ltracuup6gp4vkyi4e5s42ooef2yd.onion](http://tmcalh6tjskfmnjsipi4tqlzcr4ltracuup6gp4vkyi4e5s42ooef2yd.onion): [@yzernik's](https://github.com/yzernik) instance, accessible over Tor
 - A static snapshot of our decommissioned test instance is available [here](https://agora-org.github.io/agora/).
-- Agora lightning payment for spreadsheets embedded in a 3rd party BTCPayServer instance:  https://modulo.network 
+- Lightning payment over tor embedded in 3rd party BTCPayServer instance:  https://modulo.network after clicking purchase button (http://jzqqbzci3b2jlnvvkuxp2gmfh7if5443ite3ho7wy3phnq7tz4tspbid.onion/files/)
 - Open an issue or submit a PR if you run an Agora instance and would like it to appear in this readme!
 
 Agora is free software developed by [@casey](https://github.com/casey/)

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ If `agora` is connected to an [LND](https://github.com/lightningnetwork/lnd) nod
 Public Agora instances:
 
 - [tmcalh6tjskfmnjsipi4tqlzcr4ltracuup6gp4vkyi4e5s42ooef2yd.onion](http://tmcalh6tjskfmnjsipi4tqlzcr4ltracuup6gp4vkyi4e5s42ooef2yd.onion): [@yzernik's](https://github.com/yzernik) instance, accessible over Tor
+- [Modulo Network mining spreadsheets](https://modulo.network). [Direct link to Agora instance.](http://jzqqbzci3b2jlnvvkuxp2gmfh7if5443ite3ho7wy3phnq7tz4tspbid.onion/files/).
 - A static snapshot of our decommissioned test instance is available [here](https://agora-org.github.io/agora/).
-- Lightning payment over tor embedded in 3rd party BTCPayServer instance:  https://modulo.network after clicking purchase button (http://jzqqbzci3b2jlnvvkuxp2gmfh7if5443ite3ho7wy3phnq7tz4tspbid.onion/files/)
 - Open an issue or submit a PR if you run an Agora instance and would like it to appear in this readme!
 
 Agora is free software developed by [@casey](https://github.com/casey/)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Public Agora instances:
 
 - [tmcalh6tjskfmnjsipi4tqlzcr4ltracuup6gp4vkyi4e5s42ooef2yd.onion](http://tmcalh6tjskfmnjsipi4tqlzcr4ltracuup6gp4vkyi4e5s42ooef2yd.onion): [@yzernik's](https://github.com/yzernik) instance, accessible over Tor
 - A static snapshot of our decommissioned test instance is available [here](https://agora-org.github.io/agora/).
+- Agora lightning payment for spreadsheets embedded in a 3rd party BTCPayServer instance:  https://modulo.network 
 - Open an issue or submit a PR if you run an Agora instance and would like it to appear in this readme!
 
 Agora is free software developed by [@casey](https://github.com/casey/)


### PR DESCRIPTION
added the instance of Agora in https://modulo.network

happy to change the wording to remove redundant information, like changing it to:

"Lightning payment over tor embedded in 3rd party BTCPay Server:  https://modulo.network"